### PR TITLE
use DataDeps.jl for downloading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,18 @@ os:
   - linux
   - osx
 julia:
-    - 0.4
-    - 0.5
-    - nightly
+  - 0.6
+  - nightly
 notifications:
   email: false
+git:
+  depth: 99999999
+
+matrix:
+  allow_failures:
+    - julia: nightly
+
+
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 script:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Julia package for using Princeton's [WordNet](https://wordnet.princeton.edu/)Â
 
 ```juila
 using WordNet
-db = DB("/Users/generativist/Data/WordNet/")
+db = DB()
 ```
 > WordNet.DB
 
@@ -80,7 +80,7 @@ The constructor `DB` can optionally take a path to a WordNet directory, containi
 This should work for any release of WordNet.
 If you do not specify such a path, WordNet 3.0 will automatically be downloaded the first time you call `DB()`.
 It will only be downloaded once.
-
+See [DataDeps.jl's readme for more information](https://github.com/oxinabox/DataDeps.jl).
 
 > George A. Miller (1995). WordNet: A Lexical Database for English. 
 > Communications of the ACM Vol. 38, No. 11: 39-41. 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ sensekeys(db, db['n', "cat"])
 
 
 ## Design consideration
-
 This package loads all of WordNet into memory. It's not terribly expensive, but it may not be suitable for all developers. 
 
 ## Wordnet Data

--- a/README.md
+++ b/README.md
@@ -76,8 +76,11 @@ sensekeys(db, db['n', "cat"])
 This package loads all of WordNet into memory. It's not terribly expensive, but it may not be suitable for all developers. 
 
 ## Wordnet Data
+The constructor `DB` can optionally take a path to a WordNet directory, containing a `dict` folder.
+This should work for any release of WordNet.
+If you do not specify such a path, WordNet 3.0 will automatically be downloaded the first time you call `DB()`.
+It will only be downloaded once.
 
-I don't include the data in this repository. Ignoring copyright concerns, I dislike big chunks of data in my `.julia/vX.X` directory. Something about it worries me. To use this library, you must download and install version 3.0 of WordNet. Download it [here](http://wordnetcode.princeton.edu/3.0/WNdb-3.0.tar.gz). Then, decompress it. The resulting directory is the one to use when constructing a `Worknet.DB` type.
 
 > George A. Miller (1995). WordNet: A Lexical Database for English. 
 > Communications of the ACM Vol. 38, No. 11: 39-41. 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
-julia 0.4
+julia 0.6
 Compat
 FactCheck
+DataDeps 0.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 Compat
 FactCheck
-DataDeps 0.2
+DataDeps 0.2.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,18 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+
+## uncomment the following lines to allow failures on nightly julia
+## (tests will run but not make your overall status red)
+matrix:
+  allow_failures:
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+
+
 
 branches:
   only:

--- a/src/WordNet.jl
+++ b/src/WordNet.jl
@@ -1,7 +1,9 @@
 module WordNet
 
 using Compat
+using DataDeps
 
+include("init.jl")
 include("pointer.jl")
 include("lemma.jl")
 include("constants.jl")

--- a/src/db.jl
+++ b/src/db.jl
@@ -6,7 +6,7 @@ immutable DB
     sensekeys::Dict{Tuple{Int, AbstractString}, AbstractString}
 end
 
-function DB(base_dir::AbstractString)
+function DB(base_dir::AbstractString=datadep"WordNet 3.0")
     DB(
         load_lemmas(base_dir),
         load_synsets(base_dir),

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,0 +1,20 @@
+function __init__()
+    RegisterDataDep("WordNet 3.0",
+        """
+        Dataset: WordNet 3.0
+        Website: https://wordnet.princeton.edu/wordnet
+
+        George A. Miller (1995). WordNet: A Lexical Database for English.
+        Communications of the ACM Vol. 38, No. 11: 39-41.
+
+        Christiane Fellbaum (1998, ed.) WordNet: An Electronic Lexical Database.
+        Cambridge, MA: MIT Press.
+
+        License:
+        WordNet Release 3.0 This software and database is being provided to you, the LICENSEE, by Princeton University under the following license. By obtaining, using and/or copying this software and database, you agree that you have read, understood, and will comply with these terms and conditions.: Permission to use, copy, modify and distribute this software and database and its documentation for any purpose and without fee or royalty is hereby granted, provided that you agree to comply with the following copyright notice and statements, including the disclaimer, and that the same appear on ALL copies of the software, database and documentation, including modifications that you make for internal use or for distribution. WordNet 3.0 Copyright 2006 by Princeton University. All rights reserved. THIS SOFTWARE AND DATABASE IS PROVIDED "AS IS" AND PRINCETON UNIVERSITY MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED. BY WAY OF EXAMPLE, BUT NOT LIMITATION, PRINCETON UNIVERSITY MAKES NO REPRESENTATIONS OR WARRANTIES OF MERCHANT- ABILITY OR FITNESS FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF THE LICENSED SOFTWARE, DATABASE OR DOCUMENTATION WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS. The name of Princeton University or Princeton may not be used in advertising or publicity pertaining to distribution of the software and/or database. Title to copyright in this software, database and any associated documentation shall at all times remain with Princeton University and LICENSEE agrees to preserve same.
+        """,
+        "http://wordnetcode.princeton.edu/3.0/WNdb-3.0.tar.gz",
+        "658b1ba191f5f98c2e9bae3e25c186013158f30ef779f191d2a44e5d25046dc8";
+        post_fetch_method = unpack
+    )
+end


### PR DESCRIPTION
Hi @jbn,
this PR makes it so that the data is automatically downloaded.
See https://github.com/oxinabox/DataDeps.jl

Using it in WordNet.jl for this, is one of packages I had in mind when I was making DataDeps.
So if it is not going to be useful for this,
I would say that it is a problem with DataDeps.jl that need to be fixed (and a failure on my part -- I'ld appreciate the feedback).


This might need to wait for https://github.com/JuliaLang/METADATA.jl/pull/13140
before it passes CI.

It also might want a CI test to check it can indeed construct one with no parameters, using the datadep.
That would involve setting the environment variable `DATADEPS_ALWAYS_ACCEPT=true` (to bypass the "Do you want to download?" screen.
Maybe even adding a cron test in travis to rerun periodically to check it the URL hasn't broken