### PR TITLE
Improve performance of `hypernyms()`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
 julia:
   - 0.7
-  - 1
+  - 1.0
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,22 +4,15 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
+  - 1
   - nightly
 notifications:
   email: false
-git:
-  depth: 99999999
 
 matrix:
   allow_failures:
     - julia: nightly
 
-
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-script:
-  - julia -e 'Pkg.clone(pwd()); Pkg.build("WordNet")'
-  - julia -e 'Pkg.test("WordNet"; coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("WordNet")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/jbn/WordNet.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/jbn/WordNet.jl?branch=master)
 [![Build status](https://ci.appveyor.com/api/projects/status/bpqbdf24thkp6ytw/branch/master?svg=true)](https://ci.appveyor.com/project/jbn/wordnet-jl/branch/master)
 
-A Julia package for using Princeton's [WordNet](https://wordnet.princeton.edu/)®, heavily inspired by [Douches](https://github.com/doches)' [rwordnet](https://github.com/doches/rwordnet).
+A Julia package for using Princeton's [WordNet](https://wordnet.princeton.edu/)®, heavily inspired by [Doches](https://github.com/doches)' [rwordnet](https://github.com/doches/rwordnet).
 
 ## Simple Demo
 
@@ -22,34 +22,34 @@ lemma = db['a', "glad"]
 ```julia
 ss = synsets(db, lemma)
 ```
-> 4-element Array{WordNet.Synset,1}:  
-> (a) glad (showing or causing joy and pleasure; especially made happy; "glad you are here"; "glad that they succeeded"; "gave a glad shout"; "a glad smile"; "heard the glad news"; "a glad occasion")   
-> (s) happy, glad (eagerly disposed to act or to be of service; "glad to help")    
-> (s) glad (feeling happy appreciation; "glad of the fire's warmth")                                                                 
-> (s) glad, beaming (cheerful and bright; "a beaming smile"; "a glad May morning")  
+> 4-element Array{WordNet.Synset,1}:
+> (a) glad (showing or causing joy and pleasure; especially made happy; "glad you are here"; "glad that they succeeded"; "gave a glad shout"; "a glad smile"; "heard the glad news"; "a glad occasion")
+> (s) happy, glad (eagerly disposed to act or to be of service; "glad to help")
+> (s) glad (feeling happy appreciation; "glad of the fire's warmth")
+> (s) glad, beaming (cheerful and bright; "a beaming smile"; "a glad May morning")
 
 ```julia
 antonyms(db, ss[1])
 ```
-> 1-element Array{WordNet.Synset,1}:  
+> 1-element Array{WordNet.Synset,1}:
 > (a) sad (experiencing or showing sorrow or unhappiness; "feeling sad because his dog had died"; "Better by far that you should forget and smile / Than that you should remember and be sad"- Christina Rossetti)
 
 ```julia
 expanded_hypernyms(db, synsets(db, db['n', "DOG"])[1])
 ```
-> 13-element Array{WordNet.Synset,1}:  
-> (n) canine, canid (any of various fissiped mammals with nonretractile claws and typically long muzzles)  
-> (n) carnivore (a terrestrial or aquatic flesh-eating mammal; "terrestrial carnivores have four or five clawed digits on each limb")  
-> (n) eutherian mammal, placental, placental mammal, eutherian (mammals having a placenta; all mammals except monotremes and marsupials)  
-> (n) mammalian, mammal (any warm-blooded vertebrate having the skin more or less covered with hair; young are born alive except for the small subclass of monotremes and nourished with milk)  
-> (n) vertebrate, craniate (animals having a bony or cartilaginous skeleton with a segmented spinal column and a large brain enclosed in a skull or cranium)  
-> (n) chordate (any animal of the phylum Chordata having a notochord or spinal column)  
-> (n) animal, creature, animate being, brute, beast, fauna (a living organism characterized by voluntary movement)  
-> (n) organism, being (a living thing that has (or can develop) the ability to act or function independently)  
-> (n) living thing, animate thing (a living (or once living) entity)  
-> (n) unit, whole (an assemblage of parts that is regarded as a single entity; "how big is that part compared to the whole?"; "the team is a unit")  
-> (n) physical object, object (a tangible and visible entity; an entity that can cast a shadow; "it was full of rackets, balls and other objects")  
-> (n) physical entity (an entity that has physical existence)  
+> 13-element Array{WordNet.Synset,1}:
+> (n) canine, canid (any of various fissiped mammals with nonretractile claws and typically long muzzles)
+> (n) carnivore (a terrestrial or aquatic flesh-eating mammal; "terrestrial carnivores have four or five clawed digits on each limb")
+> (n) eutherian mammal, placental, placental mammal, eutherian (mammals having a placenta; all mammals except monotremes and marsupials)
+> (n) mammalian, mammal (any warm-blooded vertebrate having the skin more or less covered with hair; young are born alive except for the small subclass of monotremes and nourished with milk)
+> (n) vertebrate, craniate (animals having a bony or cartilaginous skeleton with a segmented spinal column and a large brain enclosed in a skull or cranium)
+> (n) chordate (any animal of the phylum Chordata having a notochord or spinal column)
+> (n) animal, creature, animate being, brute, beast, fauna (a living organism characterized by voluntary movement)
+> (n) organism, being (a living thing that has (or can develop) the ability to act or function independently)
+> (n) living thing, animate thing (a living (or once living) entity)
+> (n) unit, whole (an assemblage of parts that is regarded as a single entity; "how big is that part compared to the whole?"; "the team is a unit")
+> (n) physical object, object (a tangible and visible entity; an entity that can cast a shadow; "it was full of rackets, balls and other objects")
+> (n) physical entity (an entity that has physical existence)
 > (n) entity (that which is perceived or known or inferred to have its own distinct existence (living or nonliving))
 
 ```julia
@@ -72,7 +72,7 @@ sensekeys(db, db['n', "cat"])
 
 
 ## Design consideration
-This package loads all of WordNet into memory. It's not terribly expensive, but it may not be suitable for all developers. 
+This package loads all of WordNet into memory. It's not terribly expensive, but it may not be suitable for all developers.
 
 ## Wordnet Data
 The constructor `DB` can optionally take a path to a WordNet directory, containing a `dict` folder.
@@ -81,5 +81,5 @@ If you do not specify such a path, WordNet 3.0 will automatically be downloaded 
 It will only be downloaded once.
 See [DataDeps.jl's readme for more information](https://github.com/oxinabox/DataDeps.jl).
 
-> George A. Miller (1995). WordNet: A Lexical Database for English. 
-> Communications of the ACM Vol. 38, No. 11: 39-41. 
+> George A. Miller (1995). WordNet: A Lexical Database for English.
+> Communications of the ACM Vol. 38, No. 11: 39-41.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,2 @@
-julia 0.7-alpha
-Compat
-FactCheck
-DataDeps 0.2.2
+julia 0.7
+DataDeps 0.5

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7-alpha
 Compat
 FactCheck
 DataDeps 0.2.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,18 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
 
-## uncomment the following lines to allow failures on nightly julia
-## (tests will run but not make your overall status red)
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# Uncomment the following lines to allow failures on nightly julia
+# (tests will run but not make your overall status red)
 matrix:
   allow_failures:
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
-
-
+  - julia_version: nightly
 
 branches:
   only:
@@ -26,19 +26,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"WordNet\"); Pkg.build(\"WordNet\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"WordNet\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e "%JL_CODECOV_SCRIPT%"

--- a/src/WordNet.jl
+++ b/src/WordNet.jl
@@ -1,6 +1,5 @@
 module WordNet
 
-using Compat
 using DataDeps
 
 include("init.jl")

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,8 +1,8 @@
-SYNSET_TYPES = @compat Dict{Char, AbstractString}(
+SYNSET_TYPES = Dict{Char, AbstractString}(
     'n' => "noun", 'v' => "verb", 'a' => "adj", 'r' => "adv"
 )
 
-NOUN_POINTERS = @compat Dict{AbstractString, AbstractString}(
+NOUN_POINTERS = Dict{AbstractString, AbstractString}(
     "-c" => "Member of this domain - TOPIC",
     "+" => "Derivationally related form",
     "%p" => "Part meronym",
@@ -23,7 +23,7 @@ NOUN_POINTERS = @compat Dict{AbstractString, AbstractString}(
     "@i" => "Instance Hypernym",
     "#m" => "Member holonym"
 )
-VERB_POINTERS = @compat Dict{AbstractString, AbstractString}(
+VERB_POINTERS = Dict{AbstractString, AbstractString}(
     "+" => "Derivationally related form",
     "@" => "Hypernym",
     ";r" => "Domain of synset - REGION",
@@ -36,7 +36,7 @@ VERB_POINTERS = @compat Dict{AbstractString, AbstractString}(
     "*" => "Entailment"
 )
 
-ADJECTIVE_POINTERS = @compat Dict{AbstractString, AbstractString}(
+ADJECTIVE_POINTERS = Dict{AbstractString, AbstractString}(
     ";r" => "Domain of synset - REGION",
     "!" => "Antonym",
     "\\" => "Pertainym (pertains to noun)",
@@ -46,7 +46,7 @@ ADJECTIVE_POINTERS = @compat Dict{AbstractString, AbstractString}(
     ";c" => "Domain of synset - TOPIC"
 )
 
-ADVERB_POINTERS = @compat Dict{AbstractString, AbstractString}(
+ADVERB_POINTERS = Dict{AbstractString, AbstractString}(
     ";r" => "Domain of synset - REGION",
     "!" => "Antonym",
     ";u" => "Domain of synset - USAGE",

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,8 +1,8 @@
-SYNSET_TYPES = Dict{Char, AbstractString}(
+SYNSET_TYPES = Dict{Char, String}(
     'n' => "noun", 'v' => "verb", 'a' => "adj", 'r' => "adv"
 )
 
-NOUN_POINTERS = Dict{AbstractString, AbstractString}(
+NOUN_POINTERS = Dict{String, String}(
     "-c" => "Member of this domain - TOPIC",
     "+" => "Derivationally related form",
     "%p" => "Part meronym",
@@ -23,7 +23,7 @@ NOUN_POINTERS = Dict{AbstractString, AbstractString}(
     "@i" => "Instance Hypernym",
     "#m" => "Member holonym"
 )
-VERB_POINTERS = Dict{AbstractString, AbstractString}(
+VERB_POINTERS = Dict{String, String}(
     "+" => "Derivationally related form",
     "@" => "Hypernym",
     ";r" => "Domain of synset - REGION",
@@ -36,7 +36,7 @@ VERB_POINTERS = Dict{AbstractString, AbstractString}(
     "*" => "Entailment"
 )
 
-ADJECTIVE_POINTERS = Dict{AbstractString, AbstractString}(
+ADJECTIVE_POINTERS = Dict{String, String}(
     ";r" => "Domain of synset - REGION",
     "!" => "Antonym",
     "\\" => "Pertainym (pertains to noun)",
@@ -46,7 +46,7 @@ ADJECTIVE_POINTERS = Dict{AbstractString, AbstractString}(
     ";c" => "Domain of synset - TOPIC"
 )
 
-ADVERB_POINTERS = Dict{AbstractString, AbstractString}(
+ADVERB_POINTERS = Dict{String, String}(
     ";r" => "Domain of synset - REGION",
     "!" => "Antonym",
     ";u" => "Domain of synset - USAGE",

--- a/src/db.jl
+++ b/src/db.jl
@@ -1,6 +1,6 @@
 export DB
 
-immutable DB
+struct DB
     lemmas::Dict{Char, Dict{AbstractString, Lemma}}
     synsets::Dict{Char, Dict{Int, Synset}}
     sensekeys::Dict{Tuple{Int, AbstractString}, AbstractString}

--- a/src/db.jl
+++ b/src/db.jl
@@ -31,7 +31,7 @@ function load_lemmas(base_dir)
         open(path_to_index_file(base_dir, pos)) do f
             for (i, line) in enumerate(eachline(f))
                 i > 29 || continue  # Skip Copyright.
-                word = line[1:(something(findfirst(isequal(' '), line), 0)-1)]
+                word = line[1:(findfirst(isequal(' '), line) - 1)]
                 d[word] = Lemma(line, i-29)
             end
         end

--- a/src/db.jl
+++ b/src/db.jl
@@ -1,9 +1,9 @@
 export DB
 
 struct DB
-    lemmas::Dict{Char, Dict{AbstractString, Lemma}}
+    lemmas::Dict{Char, Dict{String, Lemma}}
     synsets::Dict{Char, Dict{Int, Synset}}
-    sensekeys::Dict{Tuple{Int, AbstractString}, AbstractString}
+    sensekeys::Dict{Tuple{Int, String}, String}
 end
 
 function DB(base_dir::AbstractString=datadep"WordNet 3.0")
@@ -23,19 +23,19 @@ end
 Base.getindex(db::DB, word::AbstractString, pos::Char) = db[pos, word]
 
 function load_lemmas(base_dir)
-    lemmas = Dict{Char, Dict{AbstractString, Lemma}}()
+    lemmas = Dict{Char, Dict{String, Lemma}}()
 
     for pos in ['n', 'v', 'a', 'r']
-        d = Dict{AbstractString, Lemma}()
-        
+        d = Dict{String, Lemma}()
+
         open(path_to_index_file(base_dir, pos)) do f
             for (i, line) in enumerate(eachline(f))
                 i > 29 || continue  # Skip Copyright.
-                word = line[1:(search(line, ' ')-1)]
+                word = line[1:(something(findfirst(isequal(' '), line), 0)-1)]
                 d[word] = Lemma(line, i-29)
             end
         end
-        
+
         lemmas[pos] = d
     end
 
@@ -44,7 +44,7 @@ end
 
 function load_synsets(base_dir)
     synsets = Dict{Char, Dict{Int, Synset}}()
-    
+
     for pos in ('n', 'v', 'a', 'r')
         d = Dict{Int, Synset}()
 
@@ -58,15 +58,15 @@ function load_synsets(base_dir)
 
         synsets[pos] = d
     end
-    
+
     synsets
 end
 
 
 function load_sensekeys(basedir)
     path=joinpath(basedir, "dict", "index.sense")
-    sensekeys = Dict{Tuple{Int64, AbstractString}, AbstractString}()
-    
+    sensekeys = Dict{Tuple{Int64, String}, String}()
+
     for line in eachline(path)
         full_key, offset_str, sense_num_str, tagcount_str = split(line)
         lemma_name = first(split(full_key, '%'))
@@ -75,7 +75,7 @@ function load_sensekeys(basedir)
         @assert(!haskey(sensekeys, index))
         sensekeys[index] = full_key
     end
-    
+
     sensekeys
 end
 

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,5 +1,6 @@
 function __init__()
-    RegisterDataDep("WordNet 3.0",
+    register(DataDep(
+        "WordNet 3.0",
         """
         Dataset: WordNet 3.0
         Website: https://wordnet.princeton.edu/wordnet
@@ -16,5 +17,5 @@ function __init__()
         "http://wordnetcode.princeton.edu/3.0/WNdb-3.0.tar.gz",
         "658b1ba191f5f98c2e9bae3e25c186013158f30ef779f191d2a44e5d25046dc8";
         post_fetch_method = unpack
-    )
+    ))
 end

--- a/src/lemma.jl
+++ b/src/lemma.jl
@@ -3,17 +3,17 @@ export Lemma
 const SPACE = ' '
 
 struct Lemma
-    word::AbstractString
+    word::String
     pos::Char
     tagsense_count::Int
     synset_offsets::Vector{Int}
     id::Int
-    pointer_syms::Vector{AbstractString}
+    pointer_syms::Vector{String}
 end
 
 function Lemma(lexicon_line, id)
     parts = split(lexicon_line, SPACE)
-    
+
     word = popfirst!(parts)
     pos = popfirst!(parts)[1]
     synset_count = parse(Int, popfirst!(parts))
@@ -24,7 +24,7 @@ function Lemma(lexicon_line, id)
 
     tagsense_count = parse(Int, popfirst!(parts))
     synset_offsets = [parse(Int, c) for c in parts[1:synset_count]]
-    
+
     Lemma(word, pos, tagsense_count, synset_offsets, id, pointer_syms)
 end
 

--- a/src/lemma.jl
+++ b/src/lemma.jl
@@ -2,7 +2,7 @@ export Lemma
 
 const SPACE = ' '
 
-immutable Lemma
+struct Lemma
     word::AbstractString
     pos::Char
     tagsense_count::Int
@@ -14,15 +14,15 @@ end
 function Lemma(lexicon_line, id)
     parts = split(lexicon_line, SPACE)
     
-    word = shift!(parts)
-    pos = shift!(parts)[1]
-    synset_count = parse(Int, shift!(parts))
+    word = popfirst!(parts)
+    pos = popfirst!(parts)[1]
+    synset_count = parse(Int, popfirst!(parts))
 
-    n_syms = parse(Int, shift!(parts))
+    n_syms = parse(Int, popfirst!(parts))
     pointer_syms = [s for s in parts[1:n_syms]]
     parts = parts[n_syms+2:end]
 
-    tagsense_count = parse(Int, shift!(parts))
+    tagsense_count = parse(Int, popfirst!(parts))
     synset_offsets = [parse(Int, c) for c in parts[1:synset_count]]
     
     Lemma(word, pos, tagsense_count, synset_offsets, id, pointer_syms)

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -10,9 +10,16 @@ relation(db::DB, synset::Synset, pointer_sym) = map(
 )
 
 antonyms(db::DB, synset::Synset)  = relation(db, synset, ANTONYM)
-hypernyms(db::DB, synset::Synset) = get(relation(db, synset, HYPERNYM), 1, ∅)
 hyponyms(db::DB, synset::Synset)  = relation(db, synset, HYPONYM)
 
+function hypernyms(db::DB, synset::Synset)
+    for ptr in synset.pointers
+        if ptr.sym == HYPERNYM
+            return db.synsets[synset.synset_type][ptr.offset]
+        end
+    end
+    return ∅
+end
 function expanded_hypernyms(db::DB, synset::Synset)
     path = Vector{Synset}()
     

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -14,7 +14,7 @@ hypernyms(db::DB, synset::Synset) = get(relation(db, synset, HYPERNYM), 1, ∅)
 hyponyms(db::DB, synset::Synset)  = relation(db, synset, HYPONYM)
 
 function expanded_hypernyms(db::DB, synset::Synset)
-    path = @compat Vector{Synset}()
+    path = Vector{Synset}()
     
     node = hypernyms(db, synset)
     while !is_nothing(node)

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -1,4 +1,4 @@
-immutable Pointer
+struct Pointer
     sym::AbstractString
     offset::UInt32
     pos::Char

--- a/src/pointer.jl
+++ b/src/pointer.jl
@@ -1,9 +1,9 @@
 struct Pointer
-    sym::AbstractString
+    sym::String
     offset::UInt32
     pos::Char
-    source::AbstractString
-    target::AbstractString
+    source::String
+    target::String
 end
 
 Pointer(sym, offset, pos, source) = Pointer(

--- a/src/synset.jl
+++ b/src/synset.jl
@@ -1,6 +1,6 @@
 export Synset, word_count, words
 
-immutable Synset
+struct Synset
     offset::Int
     lex_filenum::Int
     word_counts::Dict{AbstractString, Int}
@@ -10,7 +10,7 @@ immutable Synset
     gloss::AbstractString
 end
 
-const ∅ = @compat Synset(
+const ∅ = Synset(
     -1, 
     -1, 
     Dict{AbstractString, Int}(),
@@ -29,24 +29,24 @@ function Synset(raw_line::AbstractString, pos::Char)
     line = split(dl_parts[1], SPACE)
     gloss = join(dl_parts[2:end], " | ")
     
-    offset = parse(Int, shift!(line))
-    lex_filenum = parse(Int, shift!(line))
-    synset_type = shift!(line)[1]
+    offset = parse(Int, popfirst!(line))
+    lex_filenum = parse(Int, popfirst!(line))
+    synset_type = popfirst!(line)[1]
 
-    n_words = parse_int_hex(shift!(line))  # hex!
+    n_words = parse_int_hex(popfirst!(line))  # hex!
     word_counts = Dict{AbstractString, Int}()
     for _ in 1:n_words
-        k = shift!(line)
-        word_counts[k] = parse_int_hex(shift!(line))
+        k = popfirst!(line)
+        word_counts[k] = parse_int_hex(popfirst!(line))
     end
 
-    n_pointers = parse(Int, shift!(line))
+    n_pointers = parse(Int, popfirst!(line))
     pointers = [
         Pointer(
-            string(shift!(line)[1]), 
-            parse(UInt, shift!(line)), 
-            shift!(line)[1], 
-            shift!(line)
+            string(popfirst!(line)[1]), 
+            parse(UInt, popfirst!(line)), 
+            popfirst!(line)[1], 
+            popfirst!(line)
         )
         for _ in 1:n_pointers
     ]

--- a/src/synset.jl
+++ b/src/synset.jl
@@ -3,17 +3,17 @@ export Synset, word_count, words
 struct Synset
     offset::Int
     lex_filenum::Int
-    word_counts::Dict{AbstractString, Int}
+    word_counts::Dict{String, Int}
     synset_type::Char
     pos::Char
     pointers::Vector{Pointer}
-    gloss::AbstractString
+    gloss::String
 end
 
 const ∅ = Synset(
-    -1, 
-    -1, 
-    Dict{AbstractString, Int}(),
+    -1,
+    -1,
+    Dict{String, Int}(),
     '-',
     '-',
     Vector{Pointer}(),
@@ -28,13 +28,13 @@ function Synset(raw_line::AbstractString, pos::Char)
     dl_parts = split(strip(raw_line), " | ")
     line = split(dl_parts[1], SPACE)
     gloss = join(dl_parts[2:end], " | ")
-    
+
     offset = parse(Int, popfirst!(line))
     lex_filenum = parse(Int, popfirst!(line))
     synset_type = popfirst!(line)[1]
 
     n_words = parse_int_hex(popfirst!(line))  # hex!
-    word_counts = Dict{AbstractString, Int}()
+    word_counts = Dict{String, Int}()
     for _ in 1:n_words
         k = popfirst!(line)
         word_counts[k] = parse_int_hex(popfirst!(line))
@@ -43,9 +43,9 @@ function Synset(raw_line::AbstractString, pos::Char)
     n_pointers = parse(Int, popfirst!(line))
     pointers = [
         Pointer(
-            string(popfirst!(line)[1]), 
-            parse(UInt, popfirst!(line)), 
-            popfirst!(line)[1], 
+            string(popfirst!(line)[1]),
+            parse(UInt, popfirst!(line)),
+            popfirst!(line)[1],
             popfirst!(line)
         )
         for _ in 1:n_pointers
@@ -67,6 +67,6 @@ word_count(synset::Synset) = length(synset.word_counts)
 words(synset::Synset) = keys(synset.word_counts)
 
 function Base.show(io::IO, synset::Synset)
-    ws = join(map(word -> replace(word, "_", " "), words(synset)), ", ")
+    ws = join([replace(word, "_" => " ") for word in words(synset)], ", ")
     print(io, "($(synset.synset_type)) $ws ($(synset.gloss))")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,10 @@
 using WordNet
-using Compat
-using FactCheck
+using Test
 
-function io_to_string(f::Function) 
+function io_to_string(f::Function)
     buff = IOBuffer()
     f(buff)
-    UTF8String(buff.data)
+    String(take!(buff))
 end
 
 include("test_pointer.jl")

--- a/test/test_db.jl
+++ b/test/test_db.jl
@@ -1,21 +1,21 @@
-facts("DB") do
+@testset "DB" begin
     mock_db = DB(
-        Dict{Char, Dict{AbstractString, Lemma}}(),
+        Dict{Char, Dict{String, Lemma}}(),
         Dict{Char, Dict{Int, Synset}}(),
-		Dict{Tuple{Int,AbstractString}, AbstractString}()
+		Dict{Tuple{Int,String}, String}()
     )
 
-    context("path_to_data_file") do 
+    @testset "path_to_data_file" begin
         expected = joinpath("MockDB", "dict", "data.verb")
-        @fact WordNet.path_to_data_file("MockDB", 'v') --> expected
+        @test WordNet.path_to_data_file("MockDB", 'v') == expected
     end
 
-    context("path_to_index_file") do 
+    @testset "path_to_index_file" begin
         expected = joinpath("MockDB", "dict", "index.verb")
-        @fact WordNet.path_to_index_file("MockDB", 'v') --> expected
+        @test WordNet.path_to_index_file("MockDB", 'v') == expected
     end
 
-    context("show") do 
-        @fact io_to_string(io -> show(io, mock_db)) --> "WordNet.DB"
+    @testset "show" begin
+        @test io_to_string(io -> show(io, mock_db)) == "WordNet.DB"
     end
 end

--- a/test/test_db.jl
+++ b/test/test_db.jl
@@ -1,5 +1,5 @@
 facts("DB") do
-    const mock_db = DB(
+    mock_db = DB(
         Dict{Char, Dict{AbstractString, Lemma}}(),
         Dict{Char, Dict{Int, Synset}}(),
 		Dict{Tuple{Int,AbstractString}, AbstractString}()

--- a/test/test_lemma.jl
+++ b/test/test_lemma.jl
@@ -1,18 +1,18 @@
-facts("Lemma") do
-    context("constructor") do 
+@testset "Lemma" begin
+    @testset "constructor" begin
         lemma = Lemma("fruit n 3 3 @ ~ + 3 3 13134947 04612722 07294550", 123)
-        
-        @fact lemma.id --> 123
-        @fact lemma.word --> "fruit"
-        @fact lemma.pos --> 'n'
-        @fact lemma.pointer_syms --> ["@", "~", "+"]
-        @fact lemma.tagsense_count --> 3
-        @fact lemma.synset_offsets --> [13134947, 4612722, 7294550]
+
+        @test lemma.id == 123
+        @test lemma.word == "fruit"
+        @test lemma.pos == 'n'
+        @test lemma.pointer_syms == ["@", "~", "+"]
+        @test lemma.tagsense_count == 3
+        @test lemma.synset_offsets == [13134947, 4612722, 7294550]
     end
 
-    context("show") do 
+    @testset "show" begin
         lemma = Lemma("fruit n 3 3 @ ~ + 3 3 13134947 04612722 07294550", 123)
 
-        @fact io_to_string(io -> show(io, lemma)) --> "fruit.n"
+        @test io_to_string(io -> show(io, lemma)) == "fruit.n"
     end
 end

--- a/test/test_operations.jl
+++ b/test/test_operations.jl
@@ -1,5 +1,5 @@
 facts("operations") do
-    const mock_db = DB(joinpath(dirname(@__FILE__), "mock_db"))
+    mock_db = DB(joinpath(dirname(@__FILE__), "mock_db"))
 
     context("getindex") do
         @fact mock_db['n', "'hood"].word --> "'hood"

--- a/test/test_operations.jl
+++ b/test/test_operations.jl
@@ -1,25 +1,25 @@
-facts("operations") do
-    mock_db = DB(joinpath(dirname(@__FILE__), "mock_db"))
+@testset "operations" begin
+    mock_db = DB(joinpath(@__DIR__, "mock_db"))
 
-    context("getindex") do
-        @fact mock_db['n', "'hood"].word --> "'hood"
-        @fact mock_db["'hood", 'n'].word --> "'hood"
+    @testset "getindex" begin
+        @test mock_db['n', "'hood"].word == "'hood"
+        @test mock_db["'hood", 'n'].word == "'hood"
     end
 
-    context("synsets") do 
+    @testset "synsets" begin
         ss = synsets(mock_db, mock_db['n', "'hood"])
 
-        @fact length(ss) --> 1
-        @fact ss[1].gloss --> "(slang) a neighborhood"
+        @test length(ss) == 1
+        @test ss[1].gloss == "(slang) a neighborhood"
     end
 
-    context("expanded_hypernyms") do
+    @testset "expanded_hypernyms" begin
         ss = synsets(mock_db, mock_db['n', "'hood"])[1]
-        @fact length(expanded_hypernyms(mock_db, ss)) --> 8
+        @test length(expanded_hypernyms(mock_db, ss)) == 8
     end
 
-    context("antonyms") do 
+    @testset "antonyms" begin
         ss = synsets(mock_db, mock_db['n', "'hood"])[1]
-        @fact length(antonyms(mock_db, ss)) --> 0
+        @test length(antonyms(mock_db, ss)) == 0
     end
 end

--- a/test/test_pointer.jl
+++ b/test/test_pointer.jl
@@ -1,21 +1,21 @@
-facts("Pointer") do
-    context("constructor") do 
+@testset "Pointer" begin
+    @testset "constructor" begin
         pointer = WordNet.Pointer("s", 123, 'v', "1234")
 
-        @fact pointer.sym    --> "s"
-        @fact pointer.offset --> 123
-        @fact pointer.pos    --> 'v'
-        @fact pointer.source --> "12"
-        @fact pointer.target --> "34"
+        @test pointer.sym    == "s"
+        @test pointer.offset == 123
+        @test pointer.pos    == 'v'
+        @test pointer.source == "12"
+        @test pointer.target == "34"
     end
 
-    context("is not semantic for non-0") do 
+    @testset "is not semantic for non-0" begin
         ptr = WordNet.Pointer("s", 123, 'v', "1234")
-        @fact WordNet.is_semantic(ptr) --> false
+        @test WordNet.is_semantic(ptr) == false
     end
 
-    context("is semantic for all-0") do 
+    @testset "is semantic for all-0" begin
         ptr = WordNet.Pointer("s", 123, 'v', "0000")
-        @fact WordNet.is_semantic(ptr) --> true
+        @test WordNet.is_semantic(ptr) == true
     end
 end

--- a/test/test_sensekeys.jl
+++ b/test/test_sensekeys.jl
@@ -1,5 +1,5 @@
 facts("sensekeys") do
-    const mock_db = DB(joinpath(dirname(@__FILE__), "mock_db"))
+    mock_db = DB(joinpath(dirname(@__FILE__), "mock_db"))
 
     
     lem = mock_db["section", 'n']

--- a/test/test_sensekeys.jl
+++ b/test/test_sensekeys.jl
@@ -1,9 +1,9 @@
-facts("sensekeys") do
-    mock_db = DB(joinpath(dirname(@__FILE__), "mock_db"))
+@testset "sensekeys" begin
+    mock_db = DB(joinpath(@__DIR__, "mock_db"))
 
-    
+
     lem = mock_db["section", 'n']
     ss = synsets(mock_db, lem)
-    @fact sensekeys(mock_db, lem) --> ["section%1:15:01::"]
-    @fact sensekey(mock_db, ss[1], lem) --> "section%1:15:01::"
+    @test sensekeys(mock_db, lem) == ["section%1:15:01::"]
+    @test sensekey(mock_db, ss[1], lem) == "section%1:15:01::"
 end

--- a/test/test_synset.jl
+++ b/test/test_synset.jl
@@ -9,7 +9,7 @@ const synset_test_line = string(
     "n 0000 ~ 13135832 n 0000 ~ 13137409 n 0000 ~ 13137672 n 0000 ~ 1313830",
     "8 n 0000 ~ 13138842 n 0000 ~ 13139055 n 0000 ~ 13139482 n 0000 ~ 13140",
     "367 n 0000 ~ 13141415 n 0000 ~ 13150378 n 0000 ~ 13150592 n 0000 | the",
-    " ripened reproductive body of a seed plant"   
+    " ripened reproductive body of a seed plant"
 )
 
 const synset_test_line_2 = string(
@@ -28,44 +28,44 @@ const synset_test_line_3 = string(
     "is marriage to Wallis Warfield Simpson created a constitutional crisis"
 )
 
-facts("Synset") do 
+@testset "Synset" begin
     ss = Synset(synset_test_line, 'n')
 
-    context("constructor") do
-        @fact ss.synset_type --> 'n'
-        @fact ss.gloss --> "the ripened reproductive body of a seed plant"
-        @fact collect(words(ss)) --> ["fruit"] 
+    @testset "constructor" begin
+        @test ss.synset_type == 'n'
+        @test ss.gloss == "the ripened reproductive body of a seed plant"
+        @test collect(words(ss)) == ["fruit"]
     end
 
-    context("parses n_words from a hex string") do
-        hex_ss = Synset(synset_test_line_2, 'n') 
-        @fact hex_ss.gloss --> "an embarrassing mistake"
+    @testset "parses n_words from a hex string" begin
+        hex_ss = Synset(synset_test_line_2, 'n')
+        @test hex_ss.gloss == "an embarrassing mistake"
     end
 
-    context("parses the lex_id as a hex string") do 
-        hex_ss = Synset(synset_test_line_3, 'n') 
+    @testset "parses the lex_id as a hex string" begin
+        hex_ss = Synset(synset_test_line_3, 'n')
     end
 
-    context("words") do 
-        @fact collect(words(ss)) --> ["fruit"] 
+    @testset "words" begin
+        @test collect(words(ss)) == ["fruit"]
     end
 
-    context("word_count") do 
-        @fact word_count(ss) --> 1
+    @testset "word_count" begin
+        @test word_count(ss) == 1
     end
 
-    context("show") do 
+    @testset "show" begin
         expected = "(n) fruit (the ripened reproductive body of a seed plant)"
-        @fact io_to_string(io -> show(io, ss)) --> expected
+        @test io_to_string(io -> show(io, ss)) == expected
     end
 
-    context("is_nothing") do
-        @fact WordNet.is_nothing(WordNet.∅) --> true
+    @testset "is_nothing" begin
+        @test WordNet.is_nothing(WordNet.∅) == true
     end
 end
 
-facts("helpers") do 
-    context("parse_int_hex") do 
-        @fact WordNet.parse_int_hex("a") --> 10
+@testset "helpers" begin
+    @testset "parse_int_hex" begin
+        @test WordNet.parse_int_hex("a") == 10
     end
 end


### PR DESCRIPTION
(This PR is based off of #12 )

The current implementation of `hypernyms()` allocates an array to hold the output of `relation()` but only takes the first element. It's quite a bit faster to just loop over the synset's pointers and return the first match. For example: 

### Setup:

```julia
julia> using WordNet, BenchmarkTools

julia> db = DB()
WordNet.DB

julia> s = synsets(db, db['n', "lemonade"])
1-element Array{Synset,1}:
 (n) lemonade (sweetened beverage of diluted lemon juice)
```

### Before:

```julia
julia> @btime hypernyms($db, $s)
  235.156 ns (6 allocations: 304 bytes)
```

### After: 

```julia
julia> @btime hypernyms($db, $s)
  30.094 ns (0 allocations: 0 bytes)
```

There's probably a way to do this in one line with `Base.Iterators`, but the for loop is the fastest implementation I've found so far, and it doesn't allocate at all. 