### PR TITLE
Update readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # WordNet
 
-[![Build Status](https://travis-ci.org/jbn/WordNet.jl.svg?branch=master)](https://travis-ci.org/jbn/WordNet.jl)
-[![Coverage Status](https://coveralls.io/repos/jbn/WordNet.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/jbn/WordNet.jl?branch=master)
-[![Build status](https://ci.appveyor.com/api/projects/status/bpqbdf24thkp6ytw/branch/master?svg=true)](https://ci.appveyor.com/project/jbn/wordnet-jl/branch/master)
+[![Build Status](https://travis-ci.org/JuliaText/WordNet.jl.svg?branch=master)](https://travis-ci.org/JuliaText/WordNet.jl)
 
 A Julia package for using Princeton's [WordNet](https://wordnet.princeton.edu/)®, heavily inspired by [Doches](https://github.com/doches)' [rwordnet](https://github.com/doches/rwordnet).
 


### PR DESCRIPTION
Updates the Travis CI badge to point to the current JuliaText URL instead of the old `jbn` URL.

I also deleted Coveralls and Appveyor badges, since neither of those services is actually turned on for this repo at its `JuliaText` URL. Even better would be to just turn those services back on, but that's not something I have permissions to do. 